### PR TITLE
supress output of bsub on import

### DIFF
--- a/ClusterWrap/__init__.py
+++ b/ClusterWrap/__init__.py
@@ -5,7 +5,7 @@ from .clusters import janelia_lsf_cluster, local_cluster
 cluster = local_cluster
 
 if which('bsub') is not None:
-    if os.system('bsub -V') != 32512:
+    test_version = os.system('bsub -V > /dev/null 2>&1')
+    # Check if version call was succesful (32512: fail, 512: Unknown option).
+    if (test_version != 32512) | (test_version != 512):
         cluster = janelia_lsf_cluster
-
-


### PR DESCRIPTION
I get this message whenever I import ClusterWrap.

> Unknown option: V
Usage:
    bsub [-cwd Working Directory Path] [-e Error Path] [-I Interactive Mode]
    [-m Node List] [-M Memory Limit] [-n Min Process] [-o Output Path] [-q
    Queue Name] [-W Time] [-x Exclusive] [-h] [script]

This suppresses the terminal output and handles this exit code scenario.